### PR TITLE
Improve portfolio layout to reduce overlapping text

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,15 +41,16 @@
 
   <!-- Main Graph View -->
   <section id="main-view" class="relative" aria-labelledby="site-title">
-    <header class="absolute top-0 left-0 p-6 md:p-8 z-10 max-w-xl">
-      <h1 id="site-title" class="text-2xl md:text-3xl font-medium">My Portfolio</h1>
-      <p class="text-gray-400 mt-2 font-light">Hover to explore connections; click a project to open its architecture. Use Tab/Enter for keyboard. Press <kbd>/</kbd> to search.</p>
+    <header class="absolute inset-x-0 top-0 p-6 md:p-8 z-10 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div class="max-w-xl">
+        <h1 id="site-title" class="text-2xl md:text-3xl font-medium">My Portfolio</h1>
+        <p class="text-gray-400 mt-2 font-light">Hover to explore connections; click a project to open its architecture. Use Tab/Enter for keyboard. Press <kbd>/</kbd> to search.</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <input id="search" placeholder="Search…" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm placeholder-gray-500 focus:outline-none focus:ring focus:ring-blue-400/40" aria-label="Search nodes" />
+        <button id="reset" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm hover:bg-gray-700">Reset</button>
+      </div>
     </header>
-
-    <div class="absolute top-4 right-4 z-10 flex items-center gap-2">
-      <input id="search" placeholder="Search…" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm placeholder-gray-500 focus:outline-none focus:ring focus:ring-blue-400/40" aria-label="Search nodes" />
-      <button id="reset" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm hover:bg-gray-700">Reset</button>
-    </div>
 
     <figure aria-label="Portfolio knowledge graph">
       <svg id="main-graph" role="img" aria-describedby="graph-desc">
@@ -59,7 +60,7 @@
     </figure>
 
     <!-- Legend -->
-    <div class="absolute bottom-4 left-4 z-10 flex items-center gap-3 text-xs">
+    <div class="absolute bottom-4 left-4 z-10 flex flex-wrap items-center gap-3 text-xs">
       <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-gray-100"></span> Project</span>
       <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-blue-500"></span> Experience</span>
       <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-gray-500"></span> Skill</span>
@@ -156,7 +157,7 @@
       .force('link', d3.forceLink(data.mainGraph.links).id(d => d.id).distance(120))
       .force('charge', d3.forceManyBody().strength(-380))
       .force('center', d3.forceCenter(width/2, height/2))
-      .force('collision', d3.forceCollide().radius(d => d.type === 'project' ? 28 : 18));
+      .force('collision', d3.forceCollide().radius(d => d.type === 'project' ? 40 : 24).strength(0.9));
 
     // Links
     const link = svg.append('g').attr('stroke', '#374151').selectAll('line')


### PR DESCRIPTION
## Summary
- Merge header and search into one responsive flex container
- Allow legend to wrap on small screens
- Increase node collision radius in D3 graph to prevent label overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b13d8ce5d883329465247540c771a5