### PR TITLE
feat: refresh site with soft pastel theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Interactive Portfolio</title>
   <meta name="description" content="Graph-based portfolio with force layout navigation and architectural drill-downs." />
-  <meta name="theme-color" content="#111827" />
+  <meta name="theme-color" content="#f8fafc" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://cdn.tailwindcss.com https://d3js.org; img-src 'self' data:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src https://cdn.tailwindcss.com https://d3js.org 'unsafe-inline'" />
 
   <!-- Tailwind CSS -->
@@ -26,14 +26,14 @@
 
   <style>
     html, body { height: 100%; }
-    body { background:#111827; color:#e5e7eb; overflow:hidden; font-weight:400; }
+    body { background:#f8fafc; color:#374151; overflow:hidden; font-weight:400; }
     .node circle { cursor:pointer; transition: transform .15s ease; }
     .node:focus-visible circle { outline: 2px solid #93C5FD; outline-offset: 2px; }
     .node circle:hover { transform: scale(1.12); }
-    .node text { font-size: 12px; font-weight: 300; pointer-events: none; text-anchor: middle; fill: #e5e7eb; }
+    .node text { font-size: 12px; font-weight: 300; pointer-events: none; text-anchor: middle; fill: #374151; }
     .link { stroke-opacity: .24; stroke-width: 1px; }
     #main-graph, #lld-svg { width: 100vw; height: 100vh; position: absolute; inset: 0; }
-    #lld-overlay { transition: opacity .25s ease; background: rgba(17,24,39,.85); backdrop-filter: blur(6px); }
+    #lld-overlay { transition: opacity .25s ease; background: rgba(248,250,252,.85); backdrop-filter: blur(6px); }
     @media (prefers-reduced-motion: reduce) { .node circle { transition:none } #lld-overlay { transition: none } }
   </style>
 </head>
@@ -44,11 +44,11 @@
     <header class="absolute inset-x-0 top-0 p-6 md:p-8 z-10 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
       <div class="max-w-xl">
         <h1 id="site-title" class="text-2xl md:text-3xl font-medium">My Portfolio</h1>
-        <p class="text-gray-400 mt-2 font-light">Hover to explore connections; click a project to open its architecture. Use Tab/Enter for keyboard. Press <kbd>/</kbd> to search.</p>
+        <p class="text-gray-600 mt-2 font-light">Hover to explore connections; click a project to open its architecture. Use Tab/Enter for keyboard. Press <kbd>/</kbd> to search.</p>
       </div>
       <div class="flex items-center gap-2">
-        <input id="search" placeholder="Search…" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm placeholder-gray-500 focus:outline-none focus:ring focus:ring-blue-400/40" aria-label="Search nodes" />
-        <button id="reset" class="px-3 py-2 rounded-lg bg-gray-800/70 text-sm hover:bg-gray-700">Reset</button>
+        <input id="search" placeholder="Search…" class="px-3 py-2 rounded-lg bg-gray-100 text-gray-700 text-sm placeholder-gray-400 focus:outline-none focus:ring focus:ring-sky-300/40" aria-label="Search nodes" />
+        <button id="reset" class="px-3 py-2 rounded-lg bg-gray-100 text-gray-700 text-sm hover:bg-gray-200">Reset</button>
       </div>
     </header>
 
@@ -61,9 +61,9 @@
 
     <!-- Legend -->
     <div class="absolute bottom-4 left-4 z-10 flex flex-wrap items-center gap-3 text-xs">
-      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-gray-100"></span> Project</span>
-      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-blue-500"></span> Experience</span>
-      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-gray-500"></span> Skill</span>
+      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-sky-200"></span> Project</span>
+      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-pink-200"></span> Experience</span>
+      <span class="inline-flex items-center gap-1"><span class="inline-block w-3 h-3 rounded-full bg-emerald-200"></span> Skill</span>
     </div>
   </section>
 
@@ -71,11 +71,11 @@
   <section id="lld-overlay" class="hidden opacity-0" aria-live="polite">
     <div class="absolute top-0 left-0 p-6 md:p-8 z-20 space-y-2">
       <div class="flex items-center gap-2">
-        <button id="back" class="bg-gray-800 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg shadow-lg transition-transform transform hover:scale-[1.03]" aria-label="Back to main graph">← Back</button>
-        <button id="download-svg" class="bg-gray-800 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg shadow-lg" aria-label="Download architecture as SVG">Download SVG</button>
+        <button id="back" class="bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium py-2 px-4 rounded-lg shadow-lg transition-transform transform hover:scale-[1.03]" aria-label="Back to main graph">← Back</button>
+        <button id="download-svg" class="bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium py-2 px-4 rounded-lg shadow-lg" aria-label="Download architecture as SVG">Download SVG</button>
       </div>
       <h2 id="lld-title" class="text-2xl md:text-3xl font-medium"></h2>
-      <p class="text-gray-400 font-light">Pan and zoom to explore. Scroll to zoom; drag empty space to pan.</p>
+      <p class="text-gray-600 font-light">Pan and zoom to explore. Scroll to zoom; drag empty space to pan.</p>
     </div>
     <svg id="lld-svg" role="img">
       <title>Project architecture tree</title>
@@ -150,7 +150,7 @@
     const svg = d3.select('#main-graph').attr('width', width).attr('height', height)
       .attr('viewBox', `0 0 ${width} ${height}`).attr('preserveAspectRatio', 'xMidYMid meet');
 
-    const color = d3.scaleOrdinal().domain(['project','experience','skill']).range(['#F3F4F6','#3B82F6','#6B7280']);
+    const color = d3.scaleOrdinal().domain(['project','experience','skill']).range(['#BAE6FD','#FBCFE8','#A7F3D0']);
 
     // Forces
     const simulation = d3.forceSimulation(data.mainGraph.nodes)
@@ -160,7 +160,7 @@
       .force('collision', d3.forceCollide().radius(d => d.type === 'project' ? 40 : 24).strength(0.9));
 
     // Links
-    const link = svg.append('g').attr('stroke', '#374151').selectAll('line')
+    const link = svg.append('g').attr('stroke', '#94A3B8').selectAll('line')
       .data(data.mainGraph.links).join('line').attr('class','link');
 
     // Nodes
@@ -176,7 +176,7 @@
     node.append('circle')
       .attr('r', d => d.type === 'project' ? 16 : 10)
       .attr('fill', d => color(d.group))
-      .attr('stroke', d => d.type === 'project' ? '#4B5563' : 'none')
+      .attr('stroke', d => d.type === 'project' ? '#94A3B8' : 'none')
       .attr('stroke-width', d => d.type === 'project' ? 2 : 0)
       .on('click', (_, d) => { if (d.type === 'project') openLLD(d.id); })
       .on('keydown', (event, d) => { if ((event.key === 'Enter' || event.key === ' ') && d.type === 'project') openLLD(d.id); });
@@ -264,7 +264,7 @@
       // Links – use a horizontal link generator
       const linkGen = d3.linkHorizontal().x(d => d.y).y(d => d.x);
       baseG.selectAll('.link').data(root.links()).join('path')
-        .attr('class', 'link').attr('fill','none').attr('stroke', '#4B5563').attr('stroke-width', 1.5)
+        .attr('class', 'link').attr('fill','none').attr('stroke', '#94A3B8').attr('stroke-width', 1.5)
         .attr('d', linkGen);
 
       // Nodes
@@ -272,13 +272,13 @@
         .attr('class', 'node').attr('transform', d => `translate(${d.y},${d.x})`);
 
       nodes.append('circle').attr('r', d => d.children ? 7.5 : 5)
-        .attr('fill', d => d.children ? '#3B82F6' : '#D1D5DB')
-        .attr('stroke', '#9CA3AF').attr('stroke-width', 1.2);
+        .attr('fill', d => d.children ? '#93C5FD' : '#E5E7EB')
+        .attr('stroke', '#94A3B8').attr('stroke-width', 1.2);
 
       nodes.append('text').text(d => d.data.name)
         .attr('dy', '0.32em').attr('x', d => d.children ? -14 : 14)
         .attr('text-anchor', d => d.children ? 'end' : 'start')
-        .attr('fill', '#D1D5DB').attr('font-size', 14).attr('font-weight', 400);
+        .attr('fill', '#374151').attr('font-size', 14).attr('font-weight', 400);
 
       // Zoom + pan (preserve the base translate)
       const zoom = d3.zoom().scaleExtent([0.3, 3]).on('zoom', (ev) => {


### PR DESCRIPTION
## Summary
- switch to light pastel color palette for a playful, crisp look
- update graph colors and legend to match the new theme
- restyle overlay controls and architecture tree with soft hues

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b13faca4a4833286b89942bc8ba3cb