### PR TITLE
feat: prevent overlap in overlay graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,8 @@
       const simulation = d3.forceSimulation(nodes)
         .force('link', d3.forceLink(links).id(d => d.id).distance(80))
         .force('charge', d3.forceManyBody().strength(-200))
-        .force('center', d3.forceCenter(w/2, h/2));
+        .force('center', d3.forceCenter(w/2, h/2))
+        .force('collision', d3.forceCollide().radius(d => 20 + d.id.length * 2));
 
       const link = lldSvg.append('g').selectAll('line').data(links).join('line')
         .attr('class', 'link').attr('stroke', '#94A3B8').attr('stroke-width', 1.5);


### PR DESCRIPTION
## Summary
- add collision force to overlay subgraph simulation to space out nodes based on label length

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b1529475e88332b967c6c28ceda628