### PR TITLE
Ensure project nodes open architecture overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,15 +204,7 @@
       .attr('class','node')
       .attr('tabindex', 0)
       .attr('role','button')
-      .attr('aria-label', d => `${d.type}: ${d.id}`);
-
-    node.append('title').text(d => d.id);
-
-    node.append('circle')
-      .attr('r', d => d.type === 'project' ? 16 : 10)
-      .attr('fill', d => color(d.group))
-      .attr('stroke', d => d.type === 'project' ? '#94A3B8' : 'none')
-      .attr('stroke-width', d => d.type === 'project' ? 2 : 0)
+      .attr('aria-label', d => `${d.type}: ${d.id}`)
       .on('click', (_, d) => {
         if (data.nodeOverlays && data.nodeOverlays[d.id]) {
           renderSubgraph(d.id);
@@ -229,6 +221,14 @@
           }
         }
       });
+
+    node.append('title').text(d => d.id);
+
+    node.append('circle')
+      .attr('r', d => d.type === 'project' ? 16 : 10)
+      .attr('fill', d => color(d.group))
+      .attr('stroke', d => d.type === 'project' ? '#94A3B8' : 'none')
+      .attr('stroke-width', d => d.type === 'project' ? 2 : 0);
 
     node.append('text').text(d => d.id).attr('dy', d => d.type === 'project' ? -22 : -14);
 


### PR DESCRIPTION
## Summary
- Attach click and keyboard handlers to entire project node group instead of circle only
- Fixes node click area so architecture overlay opens when clicking project names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b9efdd9a3c8332b06a3d058ff2941d